### PR TITLE
Fix icon import typo

### DIFF
--- a/app/cases-debug/page.tsx
+++ b/app/cases-debug/page.tsx
@@ -7,7 +7,15 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
-import { CheckCircle, XCircle, AlertCircle, Database, Key, FileText, RefreshCwIcon as Refresh } from "lucide-react"
+import {
+  CheckCircle,
+  XCircle,
+  AlertCircle,
+  Database,
+  Key,
+  FileText,
+  RefreshCw as Refresh,
+} from "lucide-react"
 
 interface DebugResult {
   success: boolean


### PR DESCRIPTION
## Summary
- fix invalid `RefreshCwIcon` import in Cases Debug page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a27b5b6c832baeeb4b5485c28408