### PR TITLE
Fix slug lookups for Notion cases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Environment variables for Notion CMS integration
+
+# Case Studies database
+CASES_TOKEN=
+CASES_DATABASE_ID=
+
+# Personal Projects database
+PERSONAL_TOKEN=
+PERSONAL_DATABASE_ID=
+
+# Commercial Projects database
+COMMERCIAL_TOKEN=
+COMMERCIAL_DATABASE_ID=
+
+# Optional general Notion token fallback
+NOTION_TOKEN=

--- a/app/api/cases/route.ts
+++ b/app/api/cases/route.ts
@@ -7,17 +7,28 @@ export async function GET() {
 
     const result = await getCaseProjects()
 
-    console.log("📊 Cases API result:", {
-      success: result.success,
-      count: result.metadata.count,
-      errors: result.metadata.errors.length,
-      warnings: result.metadata.warnings.length,
-    })
+    const metadata = {
+      count: result.data.length,
+      errors: result.error ? [result.error] : [],
+      warnings: [] as string[],
+      debugInfo: {
+        token: process.env.CASES_TOKEN ? "CASES_TOKEN" : undefined,
+        databaseId: process.env.CASES_DATABASE_ID,
+      },
+    }
 
-    return NextResponse.json(result, { status: 200 })
+    console.log("📊 Cases API result:", metadata)
+
+    return NextResponse.json(
+      {
+        success: result.success,
+        data: result.data,
+        metadata,
+      },
+      { status: 200 },
+    )
   } catch (error) {
     console.error("❌ Cases API route error:", error)
-
     return NextResponse.json(
       {
         success: false,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Navigation from "@/components/navigation"
 import BackToTop from "@/components/back-to-top"
 import Footer from "@/components/footer"
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { X } from "lucide-react"
 import { useRouter } from "next/navigation"
+import { getCaseProjects, type CaseCardProject } from "@/lib/notion-cases-client"
 
 // Project Card Component
 function ProjectCard({ project, className = "" }: { project: any; className?: string }) {
@@ -45,94 +46,13 @@ function ProjectCard({ project, className = "" }: { project: any; className?: st
 }
 
 // Three Column Works Section Component
-function ThreeColumnWorksSection({ activeFilters }: { activeFilters: string[] }) {
-  const projects = [
-    {
-      title: "MAITREYA, LOGO DESIGN, IDENTITY, PACKAGING",
-      image: "/placeholder.svg?height=150&width=200",
-      height: "300px",
-      categories: ["IDENTITY", "PACKAGING"],
-      slug: "maitreya-logo-design",
-    },
-    {
-      title: "DERZHSTAT, IDENTITY",
-      image: "/placeholder.svg?height=125&width=200",
-      height: "300px",
-      categories: ["IDENTITY"],
-      slug: "derzhstat-identity",
-    },
-    {
-      title: "CRIMES WITHOUT PUNISHMENT, 3D VISUALISATION",
-      image: "/placeholder.svg?height=175&width=200",
-      height: "300px",
-      categories: ["3D VISUALISATION"],
-      slug: "crimes-without-punishment",
-    },
-    {
-      title: "BICKERSTAFF, IDENTITY, CREATIVE CODING",
-      image: "/placeholder.svg?height=140&width=200",
-      height: "300px",
-      categories: ["IDENTITY", "CREATIVE CODING"],
-      slug: "bickerstaff-identity",
-    },
-    {
-      title: "BIRDING VISION, 3D VISUALISATION",
-      image: "/placeholder.svg?height=160&width=200",
-      height: "300px",
-      categories: ["3D VISUALISATION"],
-      slug: "birding-vision",
-    },
-    {
-      title: "FRESH BLACK COLD BREW, PACKAGING",
-      image: "/placeholder.svg?height=150&width=200",
-      height: "300px",
-      comingSoon: true,
-      categories: ["PACKAGING"],
-      slug: "fresh-black-cold-brew",
-    },
-    {
-      title: "GALYCHYNA, PACKAGING",
-      image: "/placeholder.svg?height=140&width=200",
-      height: "300px",
-      categories: ["PACKAGING"],
-      slug: "galychyna-packaging",
-    },
-    {
-      title: "LEZO, FONT DESIGN",
-      image: "/placeholder.svg?height=175&width=200",
-      height: "300px",
-      categories: ["IDENTITY"],
-      slug: "lezo-font-design",
-    },
-    {
-      title: "ETNODIM, 3D VISUALISATION, CLOTH SIMULATION",
-      image: "/placeholder.svg?height=150&width=200",
-      height: "300px",
-      categories: ["3D VISUALISATION"],
-      slug: "etnodim-3d-visualisation",
-    },
-    {
-      title: "GALYCHYNA, VISUALS",
-      image: "/placeholder.svg?height=160&width=200",
-      height: "300px",
-      categories: ["IDENTITY"],
-      slug: "galychyna-visuals",
-    },
-    {
-      title: "PEN INK, PACKAGING",
-      image: "/placeholder.svg?height=145&width=200",
-      height: "300px",
-      categories: ["PACKAGING"],
-      slug: "pen-ink-packaging",
-    },
-    {
-      title: "BRAND UKRAINE, IDENTITY",
-      image: "/placeholder.svg?height=155&width=200",
-      height: "300px",
-      categories: ["IDENTITY"],
-      slug: "brand-ukraine-identity",
-    },
-  ]
+function ThreeColumnWorksSection({
+  projects,
+  activeFilters,
+}: {
+  projects: CaseCardProject[]
+  activeFilters: string[]
+}) {
 
   // Filter projects based on active filters
   const filteredProjects =
@@ -198,8 +118,24 @@ function ThreeColumnWorksSection({ activeFilters }: { activeFilters: string[] })
 
 export default function Home() {
   const [activeFilters, setActiveFilters] = useState<string[]>([])
+  const [projects, setProjects] = useState<CaseCardProject[]>([])
+  const [loading, setLoading] = useState(true)
 
-  const filterCategories = ["PACKAGING", "IDENTITY", "3D VISUALISATION", "CREATIVE CODING"]
+  const filterCategories = Array.from(
+    new Set(projects.flatMap((p) => p.categories)),
+  )
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getCaseProjects()
+        setProjects(data)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
 
   const toggleFilter = (filter: string) => {
     setActiveFilters((prev) => (prev.includes(filter) ? prev.filter((f) => f !== filter) : [...prev, filter]))
@@ -207,6 +143,14 @@ export default function Home() {
 
   const clearFilters = () => {
     setActiveFilters([])
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-gray-600">Loading projects...</p>
+      </div>
+    )
   }
 
   return (
@@ -351,7 +295,7 @@ export default function Home() {
         </div>
 
         {/* Three Column Works Section */}
-        <ThreeColumnWorksSection activeFilters={activeFilters} />
+        <ThreeColumnWorksSection projects={projects} activeFilters={activeFilters} />
 
         {/* Footer Section */}
         <Footer />

--- a/lib/notion-cases-client.ts
+++ b/lib/notion-cases-client.ts
@@ -1,0 +1,38 @@
+export interface CaseCardProject {
+  title: string
+  categories: string[]
+  image: string
+  slug: string
+  comingSoon?: boolean
+}
+
+// Fetch case projects from the API route
+export async function getCaseProjects(): Promise<CaseCardProject[]> {
+  try {
+    const res = await fetch('/api/cases', {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
+    })
+
+    if (!res.ok) {
+      console.error(`Failed to fetch /api/cases: ${res.status}`)
+      return []
+    }
+
+    const data = await res.json()
+    if (!data?.data) return []
+
+    return data.data.map((p: any) => ({
+      title: p.projectTitle,
+      categories: Array.isArray(p.categoryTags)
+        ? p.categoryTags.map((c: string) => c.toUpperCase())
+        : [],
+      image: p.thumbnail || p.introImage || '/placeholder.svg',
+      slug: p.slug,
+      comingSoon: p.comingSoon,
+    }))
+  } catch (error) {
+    console.error('Error fetching case projects:', error)
+    return []
+  }
+}

--- a/lib/notion-cases.ts
+++ b/lib/notion-cases.ts
@@ -124,78 +124,19 @@ export async function getCaseBySlug(slug: string): Promise<CaseProject | null> {
   try {
     console.log(`🔍 Fetching case project by slug: ${slug}`)
 
-    const notion = new Client({
-      auth: process.env.CASES_TOKEN,
-    })
+    // Reuse the getCaseProjects function to fetch all published projects
+    const result = await getCaseProjects()
 
-    const response = await notion.databases.query({
-      database_id: process.env.CASES_DATABASE_ID!,
-      filter: {
-        and: [
-          {
-            property: "Slug",
-            rich_text: {
-              equals: slug,
-            },
-          },
-          {
-            property: "publish",
-            checkbox: {
-              equals: true,
-            },
-          },
-        ],
-      },
-    })
-
-    if (response.results.length === 0) {
-      console.log(`❌ No published project found with slug: ${slug}`)
+    if (!result.success) {
+      console.error(`❌ Failed to fetch projects: ${result.error || "Unknown error"}`)
       return null
     }
 
-    const page = response.results[0] as any
-    const properties = page.properties
+    const project = result.data.find((p) => p.slug === slug)
 
-    // Helper function to extract text from rich text
-    const getRichText = (richTextArray: any[]) => {
-      return richTextArray?.map((text: any) => text.plain_text).join("") || ""
-    }
-
-    // Helper function to extract files
-    const getFiles = (filesArray: any[]) => {
-      return (
-        filesArray
-          ?.map((file: any) => {
-            if (file.type === "file") {
-              return file.file.url
-            } else if (file.type === "external") {
-              return file.external.url
-            }
-            return ""
-          })
-          .filter(Boolean) || []
-      )
-    }
-
-    // Helper function to extract multi-select
-    const getMultiSelect = (multiSelectArray: any[]) => {
-      return multiSelectArray?.map((item: any) => item.name) || []
-    }
-
-    const project: CaseProject = {
-      id: page.id,
-      projectTitle: properties["projectTitle"]?.title?.[0]?.plain_text || "",
-      slug: generateSlugFromTitle(properties["projectTitle"]?.title?.[0]?.plain_text || ""),
-      description: getRichText(properties["description"]?.rich_text || []),
-      team: getRichText(properties["team"]?.rich_text || []),
-      categoryTags: getMultiSelect(properties["categoryTags"]?.multi_select || []),
-      thumbnail: getFiles(properties["thumbnail"]?.files || [])[0] || "",
-      introImage: getFiles(properties["introImage"]?.files || [])[0] || "",
-      projectMedia: getFiles(properties["projectMedia"]?.files || []),
-      draftProcess: getFiles(properties["draftProcess"]?.files || []),
-      publish: properties["publish"]?.checkbox || false,
-      comingSoon: properties["comingSoon"]?.checkbox || false,
-      link: properties["link"]?.url || "", // Optional field
+    if (!project) {
+      console.log(`❌ No published project found with slug: ${slug}`)
+      return null
     }
 
     console.log(`✅ Found project: ${project.projectTitle}`)


### PR DESCRIPTION
## Summary
- add client-side fetcher for cases
- compute metadata in `/api/cases` response
- load case projects on the home page from the API

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a2b2d888832bbbf6cf9ff743aa28